### PR TITLE
Auto-detect PKS and change mount points accordingly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ checkfmt:
 
 lint:
 	@echo "golint"
-	go get -v github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 	for file in $$(find . -name '*.go' | grep -v vendor | \
 																			grep -v '\.pb\.go' | \
 																			grep -v '\.pb\.gw\.go' | \

--- a/cmd/px-node-wiper/px-node-wiper.sh
+++ b/cmd/px-node-wiper/px-node-wiper.sh
@@ -3,6 +3,7 @@
 WAIT=0 # 0 means don't wait. Run to completion.
 STATUS_FILE=/tmp/px-node-wipe-done
 ETCPWX=/etc/pwx
+OPTPWX=/opt/pwx
 HOSTPROC1_NS=/hostproc/1/ns
 PXCTL=/opt/pwx/bin/pxctl
 
@@ -84,7 +85,7 @@ run_with_nsenter "rm -rf /etc/systemd/system/portworx.service" false
 run_with_nsenter "rm -rf /etc/systemd/system/portworx-reboot.service" false
 
 # unmount oci
-run_with_nsenter "umount /opt/pwx/oci" true
+run_with_nsenter "umount $OPTPWX/oci" true
 
 # pxctl node wipe
 if [ -f "$PXCTL" ]; then
@@ -97,7 +98,7 @@ else
 fi
 
 # Remove binary files
-run_with_nsenter "rm -fr /opt/pwx" false
+run_with_nsenter "rm -fr $OPTPWX" false
 
 # Remove configuration files
 chattr -i /etc/pwx/.private.json || true


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>


**What this PR does / why we need it**:  docker.sock, /etc/pwx and /opt/pwx mounts are different for PKS. The wipe and upgrade scripts need to detect PKS and use these.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

