### PR TITLE
volume placement strategies should be cluster scoped

### DIFF
--- a/pkg/apis/portworx/v1beta1/types.go
+++ b/pkg/apis/portworx/v1beta1/types.go
@@ -128,6 +128,7 @@ type Placement struct {
 
 // +genclient
 // +genclient:noStatus
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // VolumePlacementStrategy specifies a spec for volume placement in the cluster

--- a/pkg/client/clientset/versioned/typed/portworx/v1beta1/fake/fake_portworx_client.go
+++ b/pkg/client/clientset/versioned/typed/portworx/v1beta1/fake/fake_portworx_client.go
@@ -32,8 +32,8 @@ func (c *FakePortworxV1beta1) Clusters(namespace string) v1beta1.ClusterInterfac
 	return &FakeClusters{c, namespace}
 }
 
-func (c *FakePortworxV1beta1) VolumePlacementStrategies(namespace string) v1beta1.VolumePlacementStrategyInterface {
-	return &FakeVolumePlacementStrategies{c, namespace}
+func (c *FakePortworxV1beta1) VolumePlacementStrategies() v1beta1.VolumePlacementStrategyInterface {
+	return &FakeVolumePlacementStrategies{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/clientset/versioned/typed/portworx/v1beta1/fake/fake_volumeplacementstrategy.go
+++ b/pkg/client/clientset/versioned/typed/portworx/v1beta1/fake/fake_volumeplacementstrategy.go
@@ -31,7 +31,6 @@ import (
 // FakeVolumePlacementStrategies implements VolumePlacementStrategyInterface
 type FakeVolumePlacementStrategies struct {
 	Fake *FakePortworxV1beta1
-	ns   string
 }
 
 var volumeplacementstrategiesResource = schema.GroupVersionResource{Group: "portworx.io", Version: "v1beta1", Resource: "volumeplacementstrategies"}
@@ -41,8 +40,7 @@ var volumeplacementstrategiesKind = schema.GroupVersionKind{Group: "portworx.io"
 // Get takes name of the volumePlacementStrategy, and returns the corresponding volumePlacementStrategy object, and an error if there is any.
 func (c *FakeVolumePlacementStrategies) Get(name string, options v1.GetOptions) (result *v1beta1.VolumePlacementStrategy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(volumeplacementstrategiesResource, c.ns, name), &v1beta1.VolumePlacementStrategy{})
-
+		Invokes(testing.NewRootGetAction(volumeplacementstrategiesResource, name), &v1beta1.VolumePlacementStrategy{})
 	if obj == nil {
 		return nil, err
 	}
@@ -52,8 +50,7 @@ func (c *FakeVolumePlacementStrategies) Get(name string, options v1.GetOptions) 
 // List takes label and field selectors, and returns the list of VolumePlacementStrategies that match those selectors.
 func (c *FakeVolumePlacementStrategies) List(opts v1.ListOptions) (result *v1beta1.VolumePlacementStrategyList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(volumeplacementstrategiesResource, volumeplacementstrategiesKind, c.ns, opts), &v1beta1.VolumePlacementStrategyList{})
-
+		Invokes(testing.NewRootListAction(volumeplacementstrategiesResource, volumeplacementstrategiesKind, opts), &v1beta1.VolumePlacementStrategyList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,15 +71,13 @@ func (c *FakeVolumePlacementStrategies) List(opts v1.ListOptions) (result *v1bet
 // Watch returns a watch.Interface that watches the requested volumePlacementStrategies.
 func (c *FakeVolumePlacementStrategies) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(volumeplacementstrategiesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(volumeplacementstrategiesResource, opts))
 }
 
 // Create takes the representation of a volumePlacementStrategy and creates it.  Returns the server's representation of the volumePlacementStrategy, and an error, if there is any.
 func (c *FakeVolumePlacementStrategies) Create(volumePlacementStrategy *v1beta1.VolumePlacementStrategy) (result *v1beta1.VolumePlacementStrategy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(volumeplacementstrategiesResource, c.ns, volumePlacementStrategy), &v1beta1.VolumePlacementStrategy{})
-
+		Invokes(testing.NewRootCreateAction(volumeplacementstrategiesResource, volumePlacementStrategy), &v1beta1.VolumePlacementStrategy{})
 	if obj == nil {
 		return nil, err
 	}
@@ -92,8 +87,7 @@ func (c *FakeVolumePlacementStrategies) Create(volumePlacementStrategy *v1beta1.
 // Update takes the representation of a volumePlacementStrategy and updates it. Returns the server's representation of the volumePlacementStrategy, and an error, if there is any.
 func (c *FakeVolumePlacementStrategies) Update(volumePlacementStrategy *v1beta1.VolumePlacementStrategy) (result *v1beta1.VolumePlacementStrategy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(volumeplacementstrategiesResource, c.ns, volumePlacementStrategy), &v1beta1.VolumePlacementStrategy{})
-
+		Invokes(testing.NewRootUpdateAction(volumeplacementstrategiesResource, volumePlacementStrategy), &v1beta1.VolumePlacementStrategy{})
 	if obj == nil {
 		return nil, err
 	}
@@ -103,14 +97,13 @@ func (c *FakeVolumePlacementStrategies) Update(volumePlacementStrategy *v1beta1.
 // Delete takes name of the volumePlacementStrategy and deletes it. Returns an error if one occurs.
 func (c *FakeVolumePlacementStrategies) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(volumeplacementstrategiesResource, c.ns, name), &v1beta1.VolumePlacementStrategy{})
-
+		Invokes(testing.NewRootDeleteAction(volumeplacementstrategiesResource, name), &v1beta1.VolumePlacementStrategy{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeVolumePlacementStrategies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(volumeplacementstrategiesResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(volumeplacementstrategiesResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.VolumePlacementStrategyList{})
 	return err
@@ -119,8 +112,7 @@ func (c *FakeVolumePlacementStrategies) DeleteCollection(options *v1.DeleteOptio
 // Patch applies the patch and returns the patched volumePlacementStrategy.
 func (c *FakeVolumePlacementStrategies) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.VolumePlacementStrategy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(volumeplacementstrategiesResource, c.ns, name, data, subresources...), &v1beta1.VolumePlacementStrategy{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(volumeplacementstrategiesResource, name, data, subresources...), &v1beta1.VolumePlacementStrategy{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset/versioned/typed/portworx/v1beta1/portworx_client.go
+++ b/pkg/client/clientset/versioned/typed/portworx/v1beta1/portworx_client.go
@@ -40,8 +40,8 @@ func (c *PortworxV1beta1Client) Clusters(namespace string) ClusterInterface {
 	return newClusters(c, namespace)
 }
 
-func (c *PortworxV1beta1Client) VolumePlacementStrategies(namespace string) VolumePlacementStrategyInterface {
-	return newVolumePlacementStrategies(c, namespace)
+func (c *PortworxV1beta1Client) VolumePlacementStrategies() VolumePlacementStrategyInterface {
+	return newVolumePlacementStrategies(c)
 }
 
 // NewForConfig creates a new PortworxV1beta1Client for the given config.

--- a/pkg/client/clientset/versioned/typed/portworx/v1beta1/volumeplacementstrategy.go
+++ b/pkg/client/clientset/versioned/typed/portworx/v1beta1/volumeplacementstrategy.go
@@ -30,7 +30,7 @@ import (
 // VolumePlacementStrategiesGetter has a method to return a VolumePlacementStrategyInterface.
 // A group's client should implement this interface.
 type VolumePlacementStrategiesGetter interface {
-	VolumePlacementStrategies(namespace string) VolumePlacementStrategyInterface
+	VolumePlacementStrategies() VolumePlacementStrategyInterface
 }
 
 // VolumePlacementStrategyInterface has methods to work with VolumePlacementStrategy resources.
@@ -49,14 +49,12 @@ type VolumePlacementStrategyInterface interface {
 // volumePlacementStrategies implements VolumePlacementStrategyInterface
 type volumePlacementStrategies struct {
 	client rest.Interface
-	ns     string
 }
 
 // newVolumePlacementStrategies returns a VolumePlacementStrategies
-func newVolumePlacementStrategies(c *PortworxV1beta1Client, namespace string) *volumePlacementStrategies {
+func newVolumePlacementStrategies(c *PortworxV1beta1Client) *volumePlacementStrategies {
 	return &volumePlacementStrategies{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -64,7 +62,6 @@ func newVolumePlacementStrategies(c *PortworxV1beta1Client, namespace string) *v
 func (c *volumePlacementStrategies) Get(name string, options v1.GetOptions) (result *v1beta1.VolumePlacementStrategy, err error) {
 	result = &v1beta1.VolumePlacementStrategy{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("volumeplacementstrategies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -77,7 +74,6 @@ func (c *volumePlacementStrategies) Get(name string, options v1.GetOptions) (res
 func (c *volumePlacementStrategies) List(opts v1.ListOptions) (result *v1beta1.VolumePlacementStrategyList, err error) {
 	result = &v1beta1.VolumePlacementStrategyList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("volumeplacementstrategies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -89,7 +85,6 @@ func (c *volumePlacementStrategies) List(opts v1.ListOptions) (result *v1beta1.V
 func (c *volumePlacementStrategies) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("volumeplacementstrategies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -99,7 +94,6 @@ func (c *volumePlacementStrategies) Watch(opts v1.ListOptions) (watch.Interface,
 func (c *volumePlacementStrategies) Create(volumePlacementStrategy *v1beta1.VolumePlacementStrategy) (result *v1beta1.VolumePlacementStrategy, err error) {
 	result = &v1beta1.VolumePlacementStrategy{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("volumeplacementstrategies").
 		Body(volumePlacementStrategy).
 		Do().
@@ -111,7 +105,6 @@ func (c *volumePlacementStrategies) Create(volumePlacementStrategy *v1beta1.Volu
 func (c *volumePlacementStrategies) Update(volumePlacementStrategy *v1beta1.VolumePlacementStrategy) (result *v1beta1.VolumePlacementStrategy, err error) {
 	result = &v1beta1.VolumePlacementStrategy{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("volumeplacementstrategies").
 		Name(volumePlacementStrategy.Name).
 		Body(volumePlacementStrategy).
@@ -123,7 +116,6 @@ func (c *volumePlacementStrategies) Update(volumePlacementStrategy *v1beta1.Volu
 // Delete takes name of the volumePlacementStrategy and deletes it. Returns an error if one occurs.
 func (c *volumePlacementStrategies) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("volumeplacementstrategies").
 		Name(name).
 		Body(options).
@@ -134,7 +126,6 @@ func (c *volumePlacementStrategies) Delete(name string, options *v1.DeleteOption
 // DeleteCollection deletes a collection of objects.
 func (c *volumePlacementStrategies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("volumeplacementstrategies").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -146,7 +137,6 @@ func (c *volumePlacementStrategies) DeleteCollection(options *v1.DeleteOptions, 
 func (c *volumePlacementStrategies) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.VolumePlacementStrategy, err error) {
 	result = &v1beta1.VolumePlacementStrategy{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("volumeplacementstrategies").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/informers/externalversions/portworx/v1beta1/interface.go
+++ b/pkg/client/informers/externalversions/portworx/v1beta1/interface.go
@@ -48,5 +48,5 @@ func (v *version) Clusters() ClusterInformer {
 
 // VolumePlacementStrategies returns a VolumePlacementStrategyInformer.
 func (v *version) VolumePlacementStrategies() VolumePlacementStrategyInformer {
-	return &volumePlacementStrategyInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &volumePlacementStrategyInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/client/informers/externalversions/portworx/v1beta1/volumeplacementstrategy.go
+++ b/pkg/client/informers/externalversions/portworx/v1beta1/volumeplacementstrategy.go
@@ -41,33 +41,32 @@ type VolumePlacementStrategyInformer interface {
 type volumePlacementStrategyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewVolumePlacementStrategyInformer constructs a new informer for VolumePlacementStrategy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewVolumePlacementStrategyInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredVolumePlacementStrategyInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewVolumePlacementStrategyInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredVolumePlacementStrategyInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredVolumePlacementStrategyInformer constructs a new informer for VolumePlacementStrategy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredVolumePlacementStrategyInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredVolumePlacementStrategyInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.PortworxV1beta1().VolumePlacementStrategies(namespace).List(options)
+				return client.PortworxV1beta1().VolumePlacementStrategies().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.PortworxV1beta1().VolumePlacementStrategies(namespace).Watch(options)
+				return client.PortworxV1beta1().VolumePlacementStrategies().Watch(options)
 			},
 		},
 		&portworxv1beta1.VolumePlacementStrategy{},
@@ -77,7 +76,7 @@ func NewFilteredVolumePlacementStrategyInformer(client versioned.Interface, name
 }
 
 func (f *volumePlacementStrategyInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredVolumePlacementStrategyInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredVolumePlacementStrategyInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *volumePlacementStrategyInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/listers/portworx/v1beta1/expansion_generated.go
+++ b/pkg/client/listers/portworx/v1beta1/expansion_generated.go
@@ -29,7 +29,3 @@ type ClusterNamespaceListerExpansion interface{}
 // VolumePlacementStrategyListerExpansion allows custom methods to be added to
 // VolumePlacementStrategyLister.
 type VolumePlacementStrategyListerExpansion interface{}
-
-// VolumePlacementStrategyNamespaceListerExpansion allows custom methods to be added to
-// VolumePlacementStrategyNamespaceLister.
-type VolumePlacementStrategyNamespaceListerExpansion interface{}

--- a/pkg/client/listers/portworx/v1beta1/volumeplacementstrategy.go
+++ b/pkg/client/listers/portworx/v1beta1/volumeplacementstrategy.go
@@ -29,8 +29,8 @@ import (
 type VolumePlacementStrategyLister interface {
 	// List lists all VolumePlacementStrategies in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.VolumePlacementStrategy, err error)
-	// VolumePlacementStrategies returns an object that can list and get VolumePlacementStrategies.
-	VolumePlacementStrategies(namespace string) VolumePlacementStrategyNamespaceLister
+	// Get retrieves the VolumePlacementStrategy from the index for a given name.
+	Get(name string) (*v1beta1.VolumePlacementStrategy, error)
 	VolumePlacementStrategyListerExpansion
 }
 
@@ -52,38 +52,9 @@ func (s *volumePlacementStrategyLister) List(selector labels.Selector) (ret []*v
 	return ret, err
 }
 
-// VolumePlacementStrategies returns an object that can list and get VolumePlacementStrategies.
-func (s *volumePlacementStrategyLister) VolumePlacementStrategies(namespace string) VolumePlacementStrategyNamespaceLister {
-	return volumePlacementStrategyNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// VolumePlacementStrategyNamespaceLister helps list and get VolumePlacementStrategies.
-type VolumePlacementStrategyNamespaceLister interface {
-	// List lists all VolumePlacementStrategies in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1beta1.VolumePlacementStrategy, err error)
-	// Get retrieves the VolumePlacementStrategy from the indexer for a given namespace and name.
-	Get(name string) (*v1beta1.VolumePlacementStrategy, error)
-	VolumePlacementStrategyNamespaceListerExpansion
-}
-
-// volumePlacementStrategyNamespaceLister implements the VolumePlacementStrategyNamespaceLister
-// interface.
-type volumePlacementStrategyNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all VolumePlacementStrategies in the indexer for a given namespace.
-func (s volumePlacementStrategyNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.VolumePlacementStrategy, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1beta1.VolumePlacementStrategy))
-	})
-	return ret, err
-}
-
-// Get retrieves the VolumePlacementStrategy from the indexer for a given namespace and name.
-func (s volumePlacementStrategyNamespaceLister) Get(name string) (*v1beta1.VolumePlacementStrategy, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the VolumePlacementStrategy from the index for a given name.
+func (s *volumePlacementStrategyLister) Get(name string) (*v1beta1.VolumePlacementStrategy, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>

**What this PR does / why we need it**: volume placement strategies  will be referenced in storage classes and hence should not be scoped by namespaces.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

