### PR TITLE
volume placement crd change to fix enforcement and affinity type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@
 .PHONY: version all operator run clean container deploy talisman
 
 DOCKER_HUB_TAG ?= latest
+PX_NODE_WIPER_TAG ?= latest
 DOCKER_PULLER_IMG=$(DOCKER_HUB_REPO)/docker-puller:$(DOCKER_HUB_TAG)
-PX_NODE_WIPER_IMG=$(DOCKER_HUB_REPO)/px-node-wiper:$(DOCKER_HUB_TAG)
+PX_NODE_WIPER_IMG=$(DOCKER_HUB_REPO)/px-node-wiper:$(PX_NODE_WIPER_TAG)
 TALISMAN_IMG=$(DOCKER_HUB_REPO)/talisman:$(DOCKER_HUB_TAG)
 
 SHA    := $(shell git rev-parse --short HEAD)

--- a/pkg/apis/portworx/v1beta1/types.go
+++ b/pkg/apis/portworx/v1beta1/types.go
@@ -6,6 +6,26 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// EnforcementType Defines the types of enforcement on the given rules
+type EnforcementType string
+
+const (
+	// EnforcementRequired specifies that the rule is required and must be strictly enforced
+	EnforcementRequired EnforcementType = "required"
+	// EnforcementPreferred specifies that the rule is preferred and can be best effort
+	EnforcementPreferred EnforcementType = "preferred"
+)
+
+// This specifies the type an affinity rule can take
+type AffinityRuleType string
+
+const (
+	// Affinity means the rule specifies an affinity to objects that match the below label selector requirements
+	Affinity AffinityRuleType = "affinity"
+	// AntiAffinity means the rule specifies an anti-affinity to objects that match the below label selector requirements
+	AntiAffinity AffinityRuleType = "antiAffinity"
+)
+
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -169,9 +189,9 @@ type VolumePlacementRule struct {
 	Weight int64 `json:"weight,omitempty"`
 	// Enforcement specifies the rule enforcement policy. Can take values: required or preferred.
 	// (optional)
-	Enforcement api.VolumePlacementRule_EnforcementType `json:"enforcement,omitempty"`
+	Enforcement EnforcementType `json:"enforcement,omitempty"`
 	// Type is the type of the affinity rule
-	Type api.VolumePlacementRule_AffinityRuleType `json:"type,omitempty"`
+	Type AffinityRuleType `json:"type,omitempty"`
 	// MatchExpressions is a list of label selector requirements. The requirements are ANDed.
 	MatchExpressions []*meta.LabelSelectorRequirement `json:"matchExpressions,omitempty"`
 }

--- a/pkg/apis/portworx/v1beta1/types.go
+++ b/pkg/apis/portworx/v1beta1/types.go
@@ -16,7 +16,7 @@ const (
 	EnforcementPreferred EnforcementType = "preferred"
 )
 
-// This specifies the type an affinity rule can take
+// AffinityRuleType specifies the type an affinity rule can take
 type AffinityRuleType string
 
 const (


### PR DESCRIPTION
Can't use existing osd types since they are ints and users will specify strings in the CRD spec

Signed-off-by: Harsh Desai <harsh@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

