### PR TITLE
PWX-7451: Fixing px-upgrades with Kvdb

### DIFF
--- a/pkg/cluster/px/px.go
+++ b/pkg/cluster/px/px.go
@@ -595,6 +595,11 @@ func (ops *pxClusterOps) upgradePX(newVersion string) error {
 				Resources: []string{"persistentvolumeclaims", "persistentvolumes"},
 				Verbs:     []string{"get", "list"},
 			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     []string{"get", "update", "list", "create"},
+			},
 		},
 	}
 


### PR DESCRIPTION
* talisman will insert permissions for `configmaps`, so that the "internal KVDB" px-custers can get get upgraded

Signed-off-by: @zoxpx

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
PWX-7451: px-1.7 to 2.0 upgrade fails if px using internal KVDB

**Which issue(s) this PR fixes** (optional)
PWX-7451

**Special notes for your reviewer**:

