### PR TITLE
Delete portworx namespace on wipe

### DIFF
--- a/pkg/cluster/px/px.go
+++ b/pkg/cluster/px/px.go
@@ -969,6 +969,11 @@ func (ops *pxClusterOps) deleteAllPXComponents(clusterName string) error {
 		return err
 	}
 
+	err = ops.k8sOps.DeleteNamespace(pxSecretsNamespace)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: When install, Portworx creates a namespace called "portworx". On wipe, we need to delete this.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

