### PR TITLE
Fix node wiper for kops debian AMIs

### DIFF
--- a/cmd/px-node-wiper/Dockerfile
+++ b/cmd/px-node-wiper/Dockerfile
@@ -1,4 +1,4 @@
-FROM portworx/px-enterprise:1.5.1
+FROM portworx/px-enterprise:2.0.2.1
 
 WORKDIR /
 

--- a/cmd/px-node-wiper/px-node-wiper.sh
+++ b/cmd/px-node-wiper/px-node-wiper.sh
@@ -79,8 +79,15 @@ fi
 
 
 # Remove systemd service (if any)
+
+run_with_nsenter "systemctl stop portworx" true
+run_with_nsenter "systemctl disable portworx" true
+
+# the nsenter approach above doesn't seem to work on coreos machines. To cover all scenarios,
+# try systemctl directly and ignore if it fails. This works on coreos.
 systemctl stop portworx || true
 systemctl disable portworx || true
+
 rm -rf /etc/systemd/system/*portworx*
 
 # unmount oci

--- a/cmd/talisman/talisman.go
+++ b/cmd/talisman/talisman.go
@@ -25,6 +25,8 @@ var (
 	newPXTag             string
 	newOCIMonImage       string
 	newOCIMonTag         string
+	wiperImage           string
+	wiperTag             string
 	op                   string
 	dockerRegistrySecret string
 	kubeconfig           string
@@ -102,6 +104,8 @@ func doDelete() {
 
 	opts := &px.DeleteOptions{
 		WipeCluster: wipeCluster,
+		WiperImage:  wiperImage,
+		WiperTag:    wiperTag,
 	}
 
 	err = inst.Delete(nil, opts)
@@ -127,4 +131,6 @@ func init() {
 			px.SharedAppsScaleDownAuto, px.SharedAppsScaleDownOn, px.SharedAppsScaleDownOff))
 	flag.BoolVar(&wipeCluster, "wipecluster", false, "(optional) If given, all Portworx metadata will be removed from the cluster. "+
 		"This means all the data will be wiped off from the cluster and cannot be recovered")
+	flag.StringVar(&wiperImage, "wiperimage", "", "Node wiper image to use for the upgrade")
+	flag.StringVar(&wiperTag, "wipertag", "", "Node wiper tag to use for the upgrade")
 }

--- a/pkg/cluster/px/px.go
+++ b/pkg/cluster/px/px.go
@@ -83,7 +83,8 @@ const (
 	pxSecretsNamespace              = "portworx"
 	defaultPXImage                  = "portworx/px-enterprise"
 	dockerPullerImage               = "portworx/docker-puller:latest"
-	pxNodeWiperImage                = "portworx/px-node-wiper:1.5.1"
+	defaultNodeWiperImage           = "portworx/px-node-wiper"
+	defaultNodeWiperTag             = "2.0.2.1"
 	pxdRestPort                     = 9001
 	pxServiceName                   = "portworx-service"
 	pxClusterRoleName               = "node-get-put-list-role"
@@ -145,6 +146,10 @@ type UpgradeOptions struct {
 type DeleteOptions struct {
 	// WipeCluster instructs if Portworx cluster metadata needs to be wiped off
 	WipeCluster bool
+	// WiperImage is the docker tag to use for the node wiper
+	WiperImage string
+	// WiperTag is the docker tag to use for the node wiper
+	WiperTag string
 }
 
 // Cluster an interface to manage a storage cluster
@@ -307,7 +312,7 @@ func (ops *pxClusterOps) Delete(c *apiv1beta1.Cluster, opts *DeleteOptions) erro
 		// cluster might have been started with incorrect kvdb information. So we won't be able to wipe that off.
 
 		// Wipe px from each node
-		err := ops.runPXNodeWiper(pwxHostPathRoot)
+		err := ops.runPXNodeWiper(pwxHostPathRoot, opts.WiperImage, opts.WiperTag)
 		if err != nil {
 			logrus.Warnf("Failed to wipe Portworx local node state. err: %v", err)
 		}
@@ -977,11 +982,20 @@ func (ops *pxClusterOps) deleteAllPXComponents(clusterName string) error {
 	return nil
 }
 
-func (ops *pxClusterOps) runPXNodeWiper(pwxHostPathRoot string) error {
+func (ops *pxClusterOps) runPXNodeWiper(pwxHostPathRoot, wiperImage, wiperTag string) error {
 	trueVar := true
 	labels := map[string]string{
 		"name": pxNodeWiperDaemonSetName,
 	}
+
+	if len(wiperImage) == 0 {
+		wiperImage = defaultNodeWiperImage
+	}
+
+	if len(wiperTag) == 0 {
+		wiperTag = defaultNodeWiperTag
+	}
+
 	args := []string{"-w"}
 	ds := &apps_api.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1001,7 +1015,7 @@ func (ops *pxClusterOps) runPXNodeWiper(pwxHostPathRoot string) error {
 					Containers: []corev1.Container{
 						{
 							Name:            pxNodeWiperDaemonSetName,
-							Image:           pxNodeWiperImage,
+							Image:           fmt.Sprintf("%s:%s", wiperImage, wiperTag),
 							ImagePullPolicy: corev1.PullAlways,
 							Args:            args,
 							SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>

**What this PR does / why we need it**:

Running systemctl commands directly in the default debian AMIs used in KOPS fails. It returns the "Failed to connect to bus: No data available" error.

This change now does both approaches (nsenter and systemctl). Tested on KOPS debian AMI and coreos machines. 


