### PR TITLE
Add a new argument -removedata to px-node-wiper.sh

### DIFF
--- a/pkg/cluster/px/px.go
+++ b/pkg/cluster/px/px.go
@@ -1098,7 +1098,7 @@ func (ops *pxClusterOps) runPXNodeWiper(pwxHostPathRoot, wiperImage, wiperTag st
 		wiperTag = defaultNodeWiperTag
 	}
 
-	args := []string{"-w"}
+	args := []string{"-w", "-r"}
 	ds := &apps_api.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pxNodeWiperDaemonSetName,


### PR DESCRIPTION
**What this PR does / why we need it**:
- This enables allowing two modes for wiping
  1. Uninstall -> which only removes the service files and does not clean up the drives
  2. UninstallAndWipe -> which removes the service files and cleans up the drives

- the talisman job and the daemon set it runs will alwyas do a UninstallAndWipe


