### PR TITLE
Bump node wiper to use 2.1.1 pxctl

### DIFF
--- a/cmd/px-node-wiper/Dockerfile
+++ b/cmd/px-node-wiper/Dockerfile
@@ -1,4 +1,4 @@
-FROM portworx/px-enterprise:2.0.3.6
+FROM portworx/px-enterprise:2.1.1
 
 WORKDIR /
 

--- a/pkg/cluster/px/px.go
+++ b/pkg/cluster/px/px.go
@@ -97,7 +97,7 @@ const (
 	defaultPXImage                  = "portworx/px-enterprise"
 	dockerPullerImage               = "portworx/docker-puller:latest"
 	defaultNodeWiperImage           = "portworx/px-node-wiper"
-	defaultNodeWiperTag             = "2.0.3.6"
+	defaultNodeWiperTag             = "2.1.1"
 	pxdRestPort                     = 9001
 	pxServiceName                   = "portworx-service"
 	pxClusterRoleName               = "node-get-put-list-role"


### PR DESCRIPTION
This fixes a nil panic in pxctl 2.0

https://github.com/portworx/porx/pull/3471/commits/c146afb423eb3c0a6a1bde86802700611f891a29
Signed-off-by: Harsh Desai <harsh@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

