### PR TITLE
add PX daemonset affinity to the api and wiper daemonset

### DIFF
--- a/pkg/cluster/px/px.go
+++ b/pkg/cluster/px/px.go
@@ -1399,6 +1399,7 @@ func (ops *pxClusterOps) checkAPIDaemonset(namespace string, affinity *v1.Affini
 						Labels: apiLabels,
 					},
 					Spec: corev1.PodSpec{
+						Affinity: affinity,
 						Containers: []corev1.Container{
 							{
 								Name:            pxAPIDaemonset,
@@ -1423,11 +1424,6 @@ func (ops *pxClusterOps) checkAPIDaemonset(namespace string, affinity *v1.Affini
 			},
 		}
 
-		if affinity != nil && affinity.NodeAffinity != nil {
-			apiDS.Spec.Template.Spec.Affinity = &v1.Affinity{
-				NodeAffinity: affinity.NodeAffinity,
-			}
-		}
 		_, err = ops.k8sOps.CreateDaemonSet(apiDS)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>


**What this PR does / why we need it**: This PR parses the affinity rules from the PX daemonset and uses the same rules to create the node wiper and the portworx API daemonset.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

