### PR TITLE
PWX-9687: Add 'HostPID: true' to node-wiper spec.

### DIFF
--- a/pkg/cluster/px/px.go
+++ b/pkg/cluster/px/px.go
@@ -1169,6 +1169,7 @@ func (ops *pxClusterOps) runPXNodeWiper(pwxHostPathRoot, wiperImage, wiperTag st
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
+					HostPID: true,
 					Containers: []corev1.Container{
 						{
 							Name:            pxNodeWiperDaemonSetName,


### PR DESCRIPTION
Signed-off-by: Jose Rivera <jose@portworx.com>

**What this PR does / why we need it**:
HostPID: true to allow nsenter runs to execute host commands

**Special notes for your reviewer**:
Will be used during node-wipe.
