### PR TITLE
Pwx 9687 lvm nsenter nodewipe

### DIFF
--- a/cmd/px-node-wiper/Dockerfile
+++ b/cmd/px-node-wiper/Dockerfile
@@ -1,4 +1,4 @@
-FROM portworx/px-enterprise:2.1.4
+FROM portworx/px-enterprise:2.2.0
 
 WORKDIR /
 

--- a/cmd/px-node-wiper/px-node-wiper.sh
+++ b/cmd/px-node-wiper/px-node-wiper.sh
@@ -101,8 +101,10 @@ if [ -f "$PXCTL" ]; then
     if [ "$REMOVE_DATA" = "1" ]; then
 	PXCFG=/etc/pwx/config.json
 	if [ -s ${PXCFG} -a "lvm" == "$(jq -r '.storage.type' ${PXCFG})" ]; then
-            # special case caching because it requires pkgs and mounts. So executed from the host.
+            # special case caching because it requires pkgs and mounts. So execute from px-runc on the host.
 	    run_with_nsenter "env PX_NODE_WIPER=true $PXCTL sv node-wipe --all" false
+	    # px-runc will remount so need unmount oci again
+	    run_with_nsenter "umount $OPTPWX/oci" true
 	else
             "$PXCTL" sv node-wipe --all
 	fi

--- a/cmd/px-node-wiper/px-node-wiper.sh
+++ b/cmd/px-node-wiper/px-node-wiper.sh
@@ -99,15 +99,7 @@ run_with_nsenter "umount $OPTPWX/oci" true
 # pxctl node wipe
 if [ -f "$PXCTL" ]; then
     if [ "$REMOVE_DATA" = "1" ]; then
-	PXCFG=/etc/pwx/config.json
-	if [ -s ${PXCFG} -a "lvm" == "$(jq -r '.storage.type' ${PXCFG})" ]; then
-            # special case caching because it requires pkgs and mounts. So execute from px-runc on the host.
-	    run_with_nsenter "env PX_NODE_WIPER=true $PXCTL sv node-wipe --all" false
-	    # px-runc will remount so need unmount oci again
-	    run_with_nsenter "umount $OPTPWX/oci" true
-	else
-            "$PXCTL" sv node-wipe --all
-	fi
+        "$PXCTL" sv node-wipe --all
         if [ $? -ne 0 ]; then
 	    fatal "error: node wipe failed with code: $?"
         fi


### PR DESCRIPTION
Execute lvm cache node wipe using PX runc container.    LVM caching could require daemons to be started in this case execute the node wipe using the runc container and start the deamons so node wipe does not hang.   