### PR TITLE
Delete px-essential secret during wipe

### DIFF
--- a/cmd/px-node-wiper/Dockerfile
+++ b/cmd/px-node-wiper/Dockerfile
@@ -1,4 +1,4 @@
-FROM portworx/px-enterprise:2.1.4
+FROM portworx/px-enterprise:2.5.0
 
 WORKDIR /
 

--- a/pkg/cluster/px/px.go
+++ b/pkg/cluster/px/px.go
@@ -141,6 +141,7 @@ const (
 	csiClusterRole                  = "px-csi-role"
 	csiStatefulSet                  = "px-csi-ext"
 	osbSecretName                   = "px-osb"
+	essentialSecretName             = "px-essential"
 	pxNodeWiperDaemonSetName        = "px-node-wiper"
 	pxKvdbPrefix                    = "pwx/"
 	pxImageEnvKey                   = "PX_IMAGE"
@@ -1131,6 +1132,7 @@ func (ops *pxClusterOps) deleteAllPXComponents(clusterName string) error {
 
 		secrets := []string{
 			osbSecretName,
+			essentialSecretName,
 		}
 
 		for _, sec := range secrets {


### PR DESCRIPTION

**What this PR does / why we need it**:
Delete the px-essential secret as a part of cluster wipe

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

