### PR TITLE
PWX-18849: px-node-wiper needs to mount /var/lib/osd/driver

### DIFF
--- a/pkg/cluster/px/px.go
+++ b/pkg/cluster/px/px.go
@@ -52,6 +52,7 @@ const (
 	changeCauseAnnotation  = "kubernetes.io/change-cause"
 	pxEnableLabelKey       = "px/enabled"
 	dsOptPwxVolumeName     = "optpwx"
+	dsSockPwxVolumeName    = "sockpwx"
 	dsEtcPwxVolumeName     = "etcpwx"
 	dsDbusVolumeName       = "dbus"
 	dsSysdVolumeName       = "sysdmount"
@@ -71,6 +72,7 @@ const (
 	pksPersistentStoreRoot = "/var/vcap/store"
 	pxOptPwx               = "/opt/pwx"
 	pxEtcdPwx              = "/etc/pwx"
+	pxSockPwx              = "/var/lib/osd/driver"
 )
 
 type platformType string
@@ -1268,6 +1270,10 @@ func (ops *pxClusterOps) runPXNodeWiper(pwxHostPathRoot, wiperImage, wiperTag st
 									MountPath: pxOptPwx,
 								},
 								{
+									Name:      dsSockPwxVolumeName,
+									MountPath: pxSockPwx,
+								},
+								{
 									Name:      dsDbusVolumeName,
 									MountPath: dbusPath,
 								},
@@ -1327,6 +1333,14 @@ func (ops *pxClusterOps) runPXNodeWiper(pwxHostPathRoot, wiperImage, wiperTag st
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: pwxHostPathRoot + pxOptPwx,
+								},
+							},
+						},
+						{
+							Name: dsSockPwxVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: pwxHostPathRoot + pxSockPwx,
 								},
 							},
 						},


### PR DESCRIPTION
This is needed by pxctl sv node-wipe to be able to function after the pxctl change after https://portworx.atlassian.net/browse/PWX-18104

**What this PR does / why we need it**:
px-wipe script on https://install.portworx.com/px-wipe fails, because `talisman` runs `px-node-wiper` calls `pxctl sv node-wipe`. This fails because pxctl has been changed to use local Unix DS at `/var/lib/osd/driver/`

**Which issue(s) this PR fixes** (optional)
PWX-18849

**Special notes for your reviewer**:

