### PR TITLE
PWX-19250: fix etcd authN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 services:
   - docker
 language: go

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -400,3 +400,15 @@ func (k *Instance) isPodUsingPxVolume(pod core_api.Pod) (bool, error) {
 	}
 	return false, nil
 }
+
+// GetSecret returns the secret subkey
+func (k *Instance) GetSecret(sel *core_api.SecretKeySelector, namespace string) ([]byte, error) {
+	if sel == nil {
+		return nil, nil
+	}
+	sec, err := k.k8sOps.GetSecret(sel.Name, namespace)
+	if err != nil {
+		return nil, err
+	}
+	return sec.Data[sel.Key], nil
+}


### PR DESCRIPTION
* add support for authenticated EtcD
* should work with "verbatim" user/passwd, as well as Secret-Key references via env. variables

Signed-off-by: Zoran Rajic <zox@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Cluster-wipe via `px-wipe` bootstrap would not delete content from the external EtcD, if EtcD was using username/password AuthN.

This adds a fix to the Talisman, so that the proper EtcD username/password is extracted -- be it "verbatim" value, or reference to K8s secret via the env-variables.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-19250

**Special notes for your reviewer**:

