### PR TITLE
PWX-19980: node-wiper change to always attempt to execute 'pxctl sv n…

### DIFF
--- a/cmd/px-node-wiper/px-node-wiper.sh
+++ b/cmd/px-node-wiper/px-node-wiper.sh
@@ -98,8 +98,13 @@ run_with_nsenter "umount $OPTPWX/oci" true
 if [ ! -f "$PXCTL" ]; then
   echo "warning: path $PXCTL doesn't exist. Skipping $PXCTL sv node-wipe --all"
 elif [ "$REMOVE_DATA" = "1" ]; then
-  "$PXCTL" sv node-wipe --all || \
-    fatal "error: node wipe failed with code: $?"
+  # Nodewipe needs to be run on the host if poxxible cause multipath check issues.
+  echo "Running pxctl nodewipe on the host's proc/1 namespace"
+  nsenter --mount=$HOSTPROC1_NS/mnt -- "$PXCTL" sv node-wipe --all
+  if [ "$?" -ne "0" ]; then
+      "$PXCTL" sv node-wipe --all || \
+	  fatal "error: node wipe failed with code: $?"
+  fi
 else
   echo "-removedata argument not specified. Not wiping the drives"
 fi

--- a/cmd/px-node-wiper/px-node-wiper.sh
+++ b/cmd/px-node-wiper/px-node-wiper.sh
@@ -6,7 +6,8 @@ STATUS_FILE=/tmp/px-node-wipe-done
 ETCPWX=/etc/pwx
 OPTPWX=/opt/pwx
 HOSTPROC1_NS=/hostproc/1/ns
-PXCTL=/opt/pwx/bin/pxctl
+PXCTLNM=pxctl
+PXCTL=/opt/pwx/bin/${PXCTLNM}
 
 rm -rf $STATUS_FILE
 
@@ -100,7 +101,7 @@ if [ ! -f "$PXCTL" ]; then
 elif [ "$REMOVE_DATA" = "1" ]; then
   # Nodewipe needs to be run on the host if poxxible cause multipath check issues.
   echo "Running pxctl nodewipe on the host's proc/1 namespace"
-  nsenter --mount=$HOSTPROC1_NS/mnt -- "$PXCTL" sv node-wipe --all
+  nsenter --mount=$HOSTPROC1_NS/mnt -- "$PXCTLNM" sv node-wipe --all
   if [ "$?" -ne "0" ]; then
       "$PXCTL" sv node-wipe --all || \
 	  fatal "error: node wipe failed with code: $?"


### PR DESCRIPTION
…w --all' via nsenter on the host.

Signed-off-by: Jose Rivera <jose@portworx.com>

**What this PR does / why we need it**:

Node wipe command will check the multipath devices and this needs to be done on the host.  So always run nodewipe via nsenter on the host.

**Which issue(s) this PR fixes** (optional)
PWX-19980

**Special notes for your reviewer**:

