### PR TITLE
PWX-20555: Check for and remove pwx/oci mounts before removing opt/oc…

### DIFF
--- a/cmd/px-node-wiper/px-node-wiper.sh
+++ b/cmd/px-node-wiper/px-node-wiper.sh
@@ -104,6 +104,18 @@ else
   echo "-removedata argument not specified. Not wiping the drives"
 fi
 
+# Last check to see there are left over oci mounts
+MOUNTS=$(nsenter --mount=$HOSTPROC1_NS/mnt -- mount)
+if [ $? -eq 0 ]; then
+    echo  "${MOUNTS}" |  while IFS= read -r line; do
+	MPOINT=$(echo "${line}" | awk '{ print $3 }' | egrep 'pwx/oci');
+	if [ $? -eq 0 ]; then
+	    echo "Removing left over mount: ${MPOINT}"
+	    nsenter --mount=$HOSTPROC1_NS/mnt -- umount ${MPOINT}
+	fi
+    done
+fi
+
 # Remove binary files
 run_with_nsenter "rm -fr $OPTPWX" false
 


### PR DESCRIPTION
…i directory & contents.

Signed-off-by: Jose Rivera <jose@portworx.com>

**What this PR does / why we need it**:
Make sure to remove 'pwx/oci' before removing the 'pwx/oci' directory.   On incomplete installs the mounts below were left on the host.  This prevented the wiper from removing the pwx/oci directory.   So add a check and attempt to remove any left over pwx/oci mounts.  
/dev/vda1 on /opt/pwx/oci/rootfs/etc/pwx type ext4 (rw,relatime,data=ordered)
tmpfs on /opt/pwx/oci/rootfs/run/dbus type tmpfs (rw,nosuid,noexec,relatime,size=1642504k,mode=755)
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-20555
**Special notes for your reviewer**:
This will attempt to remove any existing mounts with mount point path containing pwx/oci.  If it is unable to do so we will need to clean up manually.  
