### PR TITLE
Update node-get-put-list-role

### DIFF
--- a/pkg/cluster/px/px.go
+++ b/pkg/cluster/px/px.go
@@ -527,17 +527,32 @@ func (ops *pxClusterOps) upgradePX(spec apiv1beta1.ClusterSpec, opts *UpgradeOpt
 			{
 				APIGroups: []string{""},
 				Resources: []string{"persistentvolumeclaims", "persistentvolumes"},
+				Verbs:     []string{"get", "list", "create", "delete", "update"},
+			},
+			{
+				APIGroups: []string{"storage.k8s.io"},
+				Resources: []string{"storageclasses", "csinodes"},
 				Verbs:     []string{"get", "list"},
 			},
 			{
 				APIGroups: []string{"storage.k8s.io"},
-				Resources: []string{"storageclasses"},
-				Verbs:     []string{"get", "list"},
+				Resources: []string{"volumeattachments"},
+				Verbs:     []string{"get", "list", "create", "delete", "update"},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"configmaps"},
 				Verbs:     []string{"get", "update", "list", "create"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services"},
+				Verbs:     []string{"get", "list", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"endpoints"},
+				Verbs:     []string{"get", "list", "create", "update", "delete"},
 			},
 			{
 				APIGroups:     []string{"extensions"},


### PR DESCRIPTION
Signed-off-by: dahuang <dahuang@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We are seeing some missing RBAC permission when upgrading from 2.7.4 to 2.9.1. This PR updates it to keep it up to date with definition in px installer. 

**Which issue(s) this PR fixes** (optional)
This helps with PWX-22445

**Special notes for your reviewer**:
Test notes:
Tested on jenkins agent using the upgrade script (https://install.portworx.com/2.9.1/upgrade) but replace talisman image with custom one that includes this change. 
