### PR TITLE
PWX-22998: Update base container to latest 2.9.1 base container to pi…

### DIFF
--- a/cmd/px-node-wiper/Dockerfile
+++ b/cmd/px-node-wiper/Dockerfile
@@ -1,4 +1,4 @@
-FROM portworx/px-enterprise:2.5.0
+FROM portworx/px-lib:bionic-gs-rel-2.9.1-base-gs-grpc-1.8.0
 
 WORKDIR /
 


### PR DESCRIPTION
…ck up latest CVE fixes.

Signed-off-by: Jose Rivera <jose@portworx.com>

Updating the base conatiner to the latest the 2.9.0 base which has the latest pkgs with security updates.   The older base container was using the px-enterprise:2.5.0 container.   We are now using the just the base container for the px-enterprise 2.9.1 & 2.10.0 containers.  This fixes the vulnerabilities and makes the container much smaller.   

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-22998

**Special notes for your reviewer**:
@harsh-px I do not know to update the published container version i see in travis the following envs below are being set at the start of the build and need to update the `PX_NODE_WIPER_TAG=2.9.1`.  Please let me know how to do that before merging this in.    Thanks 

`Setting environment variables from repository settings

$ export DOCKER_HUB_1_6_TAG=[secure]

$ export DOCKER_HUB_TAG=latest

$ export DOCKER_HUB_REPO=portworx

$ export DOCKER_HUB_1_7_TAG=1.7

$ export DOCKER_USER=[secure]

$ export DOCKER_PASS=[secure]

$ export PX_NODE_WIPER_TAG=2.5.0
`
