### PR TITLE
PWX-23224: Update base container to use ubi8-minimal for security fixes.

### DIFF
--- a/Dockerfile.talisman
+++ b/Dockerfile.talisman
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7-atomic
+FROM registry.access.redhat.com/ubi8-minimal
 
 ADD bin/talisman /usr/local/bin
 


### PR DESCRIPTION
Signed-off-by: Jose Rivera <jose@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Update the Talisman base container to use ubi8-minimal to pick up security vulnerability fixes.
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-23224
**Special notes for your reviewer**:

