### PR TITLE
PWX-27003-pt1: Improved logging for Talisman / Node-wiper

### DIFF
--- a/pkg/cluster/px/px.go
+++ b/pkg/cluster/px/px.go
@@ -1537,7 +1537,7 @@ func (ops *pxClusterOps) runPXNodeWiper(pwxHostPathRoot, wiperImage, wiperTag st
 		},
 	}
 
-	// add '--debug' on TRACE debug-level
+	// pass on '--debug' flag ?
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		newArgs := make([]string, 0, len(ds.Spec.Template.Spec.Containers[0].Args))
 		newArgs = append(newArgs, "--debug")

--- a/pkg/k8sutils/logutil.go
+++ b/pkg/k8sutils/logutil.go
@@ -1,0 +1,55 @@
+package k8sutils
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+// DebugDumpObjectJS dumps object on DEBUG
+func DebugDumpObjectJS(obj interface{}, args ...interface{}) {
+	if !logrus.IsLevelEnabled(logrus.DebugLevel) {
+		return
+	}
+	dumpObjectJS(logrus.Debug, obj, args...)
+}
+
+// TraceDumpObjectJS dumps object on TRACE
+func TraceDumpObjectJS(obj interface{}, args ...interface{}) {
+	if !logrus.IsLevelEnabled(logrus.TraceLevel) {
+		return
+	}
+	dumpObjectJS(logrus.Trace, obj, args...)
+}
+
+// dumpObjectJS dumps object in JSON if given debug-level is on
+func dumpObjectJS(lvlFunc func(args ...interface{}), obj interface{}, args ...interface{}) {
+	var (
+		js  = []byte("<nil>")
+		msg = "..."
+		ok  bool
+		err error
+	)
+
+	if obj != nil {
+		if js, err = json.Marshal(obj); err != nil {
+			logrus.Errorf("log(error marshaling object %T): %s", obj, err)
+			return
+		}
+	}
+
+	switch len(args) {
+	case 0:
+		msg = fmt.Sprintf("%T =", obj)
+	case 1:
+		if msg, ok = args[0].(string); !ok {
+			logrus.Errorf("log(invalid argument type %T)", msg)
+			return
+		}
+	default:
+		msg = fmt.Sprintf(args[0].(string), args[1:]...)
+	}
+	lvlFunc("|/_  (cont below)")
+	_, _ = fmt.Fprintln(logrus.StandardLogger().Out, ">>", msg, string(js))
+}


### PR DESCRIPTION
Talisman changes:
* adding `--log <logfile>` also `--debug` and `--trace` options
  - DEBUG-level traces Kubernetes calls and errors
  - TRACE-level adds Kubernetes API output  (REST-results in JSON format)
* adding /var/cores mount
* copied DebugDumpObjectJS/TraceDumpObjectJS from porx, used to dump complex API objects

Node-wipe changes:
* increased `InitialDelaySeconds` from 30 to 120 seconds
* node-wiper stores "full trace" to /var/cores/px-node-wipe
  - always appends, will no longer maintain separate log-files
* logging activates only when `--debug` flag was passed  (passed from talisman)
* removed `sleep_forever()` -- using `sleep 1800` instead  (that's 30 minutes sleep)

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Talisman was never producing lots of logs -- this adds DEBUG/TRACE logging into talisman

Additionally, `InitialDelaySeconds: 30 [seconds]` was way to small for node-wiper
* the node-wiper will include `systemctl stop portworx`, which takes more than 30 seconds to complete
* therefore, Kubernetes would often interrupt + restart node-wiping that was "in progress"

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-27003  (part 1)

**Special notes for your reviewer**:

NOTE, the `px-wipe` bootstrap changes will be filed in a separate commit.  They will look similar to this:
```
/tmp/px-wipe.sh --log /var/cores/tatalisman.log --debug
```

Sample talisman log  (e.g. `/var/cores/tatalisman.log`)
```
------------------------------------------------------------------------------
time="2022-09-21T02:31:10Z" level=info msg="Started logging into /var/cores/tatalisman.log"
time="2022-09-21T02:31:10Z" level=info msg="Performing DELETE operation"
time="2022-09-21T02:31:10Z" level=debug msg="will use in-cluster config to create k8s client"
time="2022-09-21T02:31:10Z" level=debug msg="|/_  (cont below)"
>> DELETE options: {"WipeCluster":true,"WiperImage":"10.13.1.68/zoxpx/px-node-wiper","WiperTag":"latest"}
time="2022-09-21T02:31:10Z" level=info msg="Attempting to parse kvdb info from Portworx daemonset"
time="2022-09-21T02:31:10Z" level=debug msg="> parsed config from DS" affinity="&Affinity{NodeAffinity:&NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution:&NodeSelector{NodeSelectorTerms:[]NodeSelectorTerm{NodeSelectorTerm{MatchExpressions:[]NodeSelectorRequirement{NodeSelectorRequirement{Key:px/enabled,Operator:NotIn,Values:[false],},NodeSelectorRequirement{Key:node-role.kubernetes.io/master,Operator:DoesNotExist,Values:[],},},MatchFields:[]NodeSelectorRequirement{},},},},PreferredDuringSchedulingIgnoredDuringExecution:[]PreferredSchedulingTerm{},},PodAffinity:nil,PodAntiAffinity:nil,}" cluster-id=px-cluster-foo-bc20-795ed1a914a7 endpoints="[]" error="cluster is using internal etcd" kvdb-opts="map[]" platform=
time="2022-09-21T02:31:10Z" level=info msg="Deleting all PX Kubernetes components from the cluster in namespaces: [kube-system]"
time="2022-09-21T02:31:10Z" level=debug msg="ran DeleteDaemonSet(portworx,kube-system)" error="<nil>"
time="2022-09-21T02:31:10Z" level=debug msg="ran DeleteClusterRole(node-get-put-list-role)" error="<nil>"
time="2022-09-21T02:31:10Z" level=debug msg="ran DeleteClusterRole(stork-role)" error="<nil>"
time="2022-09-21T02:31:10Z" level=debug msg="ran DeleteClusterRole(stork-scheduler-role)" error="<nil>"
time="2022-09-21T02:31:10Z" level=debug msg="ran DeleteClusterRole(portworx-pvc-controller-role)" error="clusterroles.rbac.authorization.k8s.io \"portworx-pvc-controller-role\" not found"
time="2022-09-21T02:31:10Z" level=debug msg="ran DeleteClusterRole(px-csi-role)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteClusterRoleBinding(node-role-binding)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteClusterRoleBinding(stork-role-binding)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteClusterRoleBinding(stork-scheduler-role-binding)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteClusterRoleBinding(portworx-pvc-controller-role-binding)" error="clusterrolebindings.rbac.authorization.k8s.io \"portworx-pvc-controller-role-binding\" not found"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteClusterRoleBinding(px-csi-role-binding)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteSecret(px-cluster-foo-bc20-795ed1a914a7-px-secret,portworx)" error="secrets \"px-cluster-foo-bc20-795ed1a914a7-px-secret\" not found"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteStorageClass(stork-snapshot-sc)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteMutatingWebhookConfiguration(stork-webhooks-cfg)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteNamespace(portworx)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteConfigMap(px-attach-driveset-lock,kube-system)" error="configmaps \"px-attach-driveset-lock\" not found"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteConfigMap(px-bootstrap-pxclusterfoobc20795ed1a914a7,kube-system)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteConfigMap(px-cloud-drive-pxclusterfoobc20795ed1a914a7,kube-system)" error="configmaps \"px-cloud-drive-pxclusterfoobc20795ed1a914a7\" not found"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteDaemonSet(portworx-api,kube-system)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteDeployment(stork,kube-system)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteDeployment(stork-scheduler,kube-system)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteDeployment(portworx-pvc-controller,kube-system)" error="deployments.apps \"portworx-pvc-controller\" not found"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteDeployment(px-lighthouse,kube-system)" error="deployments.apps \"px-lighthouse\" not found"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteDeployment(px-csi-ext,kube-system)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteRole(px-role,portworx)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteRole(px-lh-role,kube-system)" error="roles.rbac.authorization.k8s.io \"px-lh-role\" not found"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteRoleBinding(px-role-binding,portworx)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteRoleBinding(px-lh-role-binding,kube-system)" error="rolebindings.rbac.authorization.k8s.io \"px-lh-role-binding\" not found"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteServiceAccount(px-account,kube-system)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteServiceAccount(px-lh-account,kube-system)" error="serviceaccounts \"px-lh-account\" not found"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteServiceAccount(stork-account,kube-system)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteServiceAccount(stork-scheduler-account,kube-system)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteServiceAccount(portworx-pvc-controller-account,kube-system)" error="serviceaccounts \"portworx-pvc-controller-account\" not found"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteServiceAccount(px-csi-account,kube-system)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteService(portworx-service,kube-system)" error="<nil>"
time="2022-09-21T02:31:11Z" level=debug msg="ran DeleteService(portworx-api,kube-system)" error="<nil>"
time="2022-09-21T02:31:12Z" level=debug msg="ran DeleteService(stork-service,kube-system)" error="<nil>"
time="2022-09-21T02:31:12Z" level=debug msg="ran DeleteService(px-lighthouse,kube-system)" error="services \"px-lighthouse\" not found"
time="2022-09-21T02:31:12Z" level=debug msg="ran DeleteService(px-csi-service,kube-system)" error="<nil>"
time="2022-09-21T02:31:12Z" level=debug msg="ran DeleteStatefulSet(px-csi-ext,kube-system)" error="statefulsets.apps \"px-csi-ext\" not found"
time="2022-09-21T02:31:12Z" level=debug msg="ran DeleteSecret(px-osb,kube-system)" error="secrets \"px-osb\" not found"
time="2022-09-21T02:31:12Z" level=debug msg="ran DeleteSecret(px-essential,kube-system)" error="secrets \"px-essential\" not found"
time="2022-09-21T02:31:13Z" level=debug msg="ran DeleteConfigMap(px-pure-cloud-drive,kube-system)" error="configmaps \"px-pure-cloud-drive\" not found"
time="2022-09-21T02:31:13Z" level=debug msg="ran DeleteConfigMap(px-lighthouse-config,kube-system)" error="configmaps \"px-lighthouse-config\" not found"
time="2022-09-21T02:31:13Z" level=debug msg="ran DeleteConfigMap(stork-config,kube-system)" error="<nil>"
time="2022-09-21T02:31:13Z" level=debug msg="ran DeleteConfigMap(px-attach-driveset-lock,kube-system)" error="configmaps \"px-attach-driveset-lock\" not found"
time="2022-09-21T02:31:13Z" level=debug msg="ran DeleteConfigMap(px-bootstrap-pxclusterfoobc20795ed1a914a7,kube-system)" error="configmaps \"px-bootstrap-pxclusterfoobc20795ed1a914a7\" not found"
time="2022-09-21T02:31:14Z" level=debug msg="ran DeleteConfigMap(px-cloud-drive-pxclusterfoobc20795ed1a914a7,kube-system)" error="configmaps \"px-cloud-drive-pxclusterfoobc20795ed1a914a7\" not found"
time="2022-09-21T02:31:14Z" level=debug msg="ran DeleteDaemonSet(px-node-wiper,kube-system) -- PRE" error="daemonsets.apps \"px-node-wiper\" not found"
time="2022-09-21T02:31:14Z" level=debug msg="ran CreateDaemonSet(kube-system/px-node-wiper)" error="<nil>"
time="2022-09-21T02:31:14Z" level=info msg="Started daemonSet: [kube-system] px-node-wiper"
time="2022-09-21T02:33:59Z" level=debug msg="ran ValidateDaemonSet(px-node-wiper,kube-system,10m0s)" error="<nil>"
time="2022-09-21T02:33:59Z" level=info msg="Validated successful run of daemonset: [kube-system] px-node-wiper"
time="2022-09-21T02:33:59Z" level=debug msg="ran DeleteDaemonSet(px-node-wiper,kube-system)" error="<nil>"
time="2022-09-21T02:33:59Z" level=info msg="Cluster is using internal etcd. No need to wipe kvdb."
time="2022-09-21T02:33:59Z" level=info msg="Delete done."
```

Sample node-wiper log  (`/var/cores/px-node-wipe.log` on every node):
```
.____________/ DEBUG-START by uid=0(root) gid=0(root) groups=0(root) as '/px-node-wiper.sh -w -r' on Wed Sep 21 02:31:15 UTC 2022
+(/px-node-wiper.sh:12): main(): WAIT=0
+(/px-node-wiper.sh:13): main(): REMOVE_DATA=0
+(/px-node-wiper.sh:14): main(): STATUS_FILE=/tmp/px-node-wipe-done
+(/px-node-wiper.sh:15): main(): ETCPWX=/etc/pwx
+(/px-node-wiper.sh:16): main(): OPTPWX=/opt/pwx
+(/px-node-wiper.sh:17): main(): HOSTPROC1_NS=/hostproc/1/ns
+(/px-node-wiper.sh:18): main(): PXCTLNM=pxctl
+(/px-node-wiper.sh:19): main(): PXCTL=/opt/pwx/bin/pxctl
+(/px-node-wiper.sh:21): main(): rm -rf /tmp/px-node-wipe-done
+(/px-node-wiper.sh:23): main(): DBUS_ADDR=/var/run/dbus/system_bus_socket
+(/px-node-wiper.sh:24): main(): export DBUS_SESSION_BUS_ADDRESS=unix:path=/var/run/dbus/system_bus_socket
+(/px-node-wiper.sh:24): main(): DBUS_SESSION_BUS_ADDRESS=unix:path=/var/run/dbus/system_bus_socket
+(/px-node-wiper.sh:60): main(): trap cleanup SIGINT SIGTERM
+(/px-node-wiper.sh:62): main(): '[' -w '!=' '' ']'
+(/px-node-wiper.sh:63): main(): case $1 in
+(/px-node-wiper.sh:64): main(): WAIT=1
+(/px-node-wiper.sh:74): main(): shift
+(/px-node-wiper.sh:62): main(): '[' -r '!=' '' ']'
+(/px-node-wiper.sh:63): main(): case $1 in
+(/px-node-wiper.sh:66): main(): REMOVE_DATA=1
+(/px-node-wiper.sh:74): main(): shift
+(/px-node-wiper.sh:62): main(): '[' '' '!=' '' ']'
+(/px-node-wiper.sh:78): main(): '[' -d /etc/pwx ']'
+(/px-node-wiper.sh:81): main(): '[' -d /hostproc/1/ns ']'
+(/px-node-wiper.sh:87): main(): run_with_nsenter 'systemctl stop portworx' true
+(/px-node-wiper.sh:45): run_with_nsenter(): '[' 2 -ne 2 ']'
+(/px-node-wiper.sh:49): run_with_nsenter(): echo 'running systemctl stop portworx on the host'\''s proc/1 namespace'
...
+(/px-node-wiper.sh:155): main(): rm -rf '/etc/pwx/.??*' /etc/pwx/px_env.bak
+(/px-node-wiper.sh:156): main(): '[' 0 -eq 0 ']'
+(/px-node-wiper.sh:157): main(): touch /tmp/px-node-wipe-done
+(/px-node-wiper.sh:158): main(): '[' 1 = 1 ']'
+(/px-node-wiper.sh:159): main(): echo 'Successfully wiped px. Sleeping...'
Successfully wiped px. Sleeping...
+(/px-node-wiper.sh:160): main(): sleep 1800
```