### PR TITLE
PWX-35213: upgrade versions

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.17.13
+FROM golang:1.21
 MAINTAINER harsh@portworx.com
 
 RUN mkdir -p /go/src/github.com/portworx/talisman

--- a/Dockerfile.talisman
+++ b/Dockerfile.talisman
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi9-minimal
 
 ADD bin/talisman /usr/local/bin
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GO     := go
 GOENV  := GOOS=linux GOARCH=amd64
 DIR=.
 
-DOCK_BUILD_CNT	:= golang:1.20.7
+DOCK_BUILD_CNT	:= golang:1.21
 
 ifndef TAGS
 TAGS := daemon

--- a/cmd/px-node-wiper/Dockerfile
+++ b/cmd/px-node-wiper/Dockerfile
@@ -1,4 +1,4 @@
-FROM portworx/px-lib:bionic-hk-rel-3.0.1-base-grpc-1.8.0-lttng-2.12-go-1.20.7
+FROM portworx/px-lib:bionic-hk-rel-3.1.0-base-grpc-1.8.0-lttng-2.12-go-1.20.7
 
 WORKDIR /
 


### PR DESCRIPTION
* talisman's base-container to UBI9
* upgraded golang to 1.21.x
* upgrade node-wiper to latest px-lib base container

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Fixing versions of the base-container, and the golang

**Which issue(s) this PR fixes** (optional)
Closes # PWX-35213

**Special notes for your reviewer**:

testing notes:

* wiping cluster worked OK

```
# export REGISTRY=10.13.1.19
# bash px-wipe.sh -I $REGISTRY/portworx/talisman -wi $REGISTRY/portworx/px-node-wiper --talismantag latest --wipertag latest

The operation will delete Portworx components and metadata from the cluster. The operation is irreversible and will lead to DATA LOSS. Do you want to continue? [y/N]:y
Parsed kubernetes versions are 1.28.4 (Server) and 1.26.4 (Client)
serviceaccount/talisman-account created
clusterrolebinding.rbac.authorization.k8s.io/talisman-role-binding created
job.batch/talisman created
Talisman job for wiping Portworx started. Monitor logs using: 'kubectl logs -n kube-system -l job-name=talisman'
Pod that will perform wipe of Portworx is still in container creating phase
waiting on talisman to complete...
Monitoring logs of pod: talisman-l4q86
time="2023-12-02T08:49:42Z" level=info msg="Running talisman: bd861fdb"
time="2023-12-02T08:49:42Z" level=info msg="Performing DELETE operation"
time="2023-12-02T08:49:42Z" level=info msg="Attempting to parse kvdb info from Portworx daemonset"
time="2023-12-02T08:49:42Z" level=info msg="Deleting all PX Kubernetes components from the cluster in namespaces: [kube-system]"
time="2023-12-02T08:49:45Z" level=info msg="Started daemonSet: [kube-system] px-node-wiper"
2023/12/02 08:49:45 app px-node-wiper is not ready yet. Cause: Observed generation is still 0. Check back status after some time Next retry in: 15s
2023/12/02 08:50:00 app px-node-wiper is not ready yet. Cause: 3 pods are not available. available: 0 ready: 0. Current pods overview:
  pod name:px-node-wiper-mw6b8 namespace:kube-system running:true ready:false node:10.13.1.17
  pod name:px-node-wiper-s5q65 namespace:kube-system running:true ready:false node:10.13.1.195
  pod name:px-node-wiper-tqrp4 namespace:kube-system running:true ready:false node:10.13.1.16
 Next retry in: 15s
2023/12/02 08:50:15 app px-node-wiper is not ready yet. Cause: 3 pods are not available. available: 0 ready: 0. Current pods overview:
  pod name:px-node-wiper-mw6b8 namespace:kube-system running:true ready:false node:10.13.1.17
  pod name:px-node-wiper-s5q65 namespace:kube-system running:true ready:false node:10.13.1.195
  pod name:px-node-wiper-tqrp4 namespace:kube-system running:true ready:false node:10.13.1.16
 Next retry in: 15s
2023/12/02 08:50:30 app px-node-wiper is not ready yet. Cause: 3 pods are not available. available: 0 ready: 0. Current pods overview:
  pod name:px-node-wiper-mw6b8 namespace:kube-system running:true ready:false node:10.13.1.17
  pod name:px-node-wiper-s5q65 namespace:kube-system running:true ready:false node:10.13.1.195
  pod name:px-node-wiper-tqrp4 namespace:kube-system running:true ready:false node:10.13.1.16
 Next retry in: 15s
2023/12/02 08:50:45 app px-node-wiper is not ready yet. Cause: 3 pods are not available. available: 0 ready: 0. Current pods overview:
  pod name:px-node-wiper-mw6b8 namespace:kube-system running:true ready:false node:10.13.1.17
  pod name:px-node-wiper-s5q65 namespace:kube-system running:true ready:false node:10.13.1.195
  pod name:px-node-wiper-tqrp4 namespace:kube-system running:true ready:false node:10.13.1.16
 Next retry in: 15s
2023/12/02 08:51:00 app px-node-wiper is not ready yet. Cause: 3 pods are not available. available: 0 ready: 0. Current pods overview:
  pod name:px-node-wiper-mw6b8 namespace:kube-system running:true ready:false node:10.13.1.17
  pod name:px-node-wiper-s5q65 namespace:kube-system running:true ready:false node:10.13.1.195
  pod name:px-node-wiper-tqrp4 namespace:kube-system running:true ready:false node:10.13.1.16
 Next retry in: 15s
2023/12/02 08:51:15 app px-node-wiper is not ready yet. Cause: 3 pods are not available. available: 0 ready: 0. Current pods overview:
  pod name:px-node-wiper-mw6b8 namespace:kube-system running:true ready:false node:10.13.1.17
  pod name:px-node-wiper-s5q65 namespace:kube-system running:true ready:false node:10.13.1.195
  pod name:px-node-wiper-tqrp4 namespace:kube-system running:true ready:false node:10.13.1.16
 Next retry in: 15s
2023/12/02 08:51:30 app px-node-wiper is not ready yet. Cause: 3 pods are not available. available: 0 ready: 0. Current pods overview:
  pod name:px-node-wiper-mw6b8 namespace:kube-system running:true ready:false node:10.13.1.17
  pod name:px-node-wiper-s5q65 namespace:kube-system running:true ready:false node:10.13.1.195
  pod name:px-node-wiper-tqrp4 namespace:kube-system running:true ready:false node:10.13.1.16
 Next retry in: 15s
2023/12/02 08:51:45 app px-node-wiper is not ready yet. Cause: 3 pods are not available. available: 0 ready: 0. Current pods overview:
  pod name:px-node-wiper-mw6b8 namespace:kube-system running:true ready:false node:10.13.1.17
  pod name:px-node-wiper-s5q65 namespace:kube-system running:true ready:false node:10.13.1.195
  pod name:px-node-wiper-tqrp4 namespace:kube-system running:true ready:false node:10.13.1.16
 Next retry in: 15s
time="2023-12-02T08:52:00Z" level=info msg="Validated successful run of daemonset: [kube-system] px-node-wiper"
time="2023-12-02T08:52:00Z" level=info msg="Creating kvdb client for: [etcd:http://10.13.1.19:2379]"
time="2023-12-02T08:52:00Z" level=info msg="Deleting Portworx kvdb tree: pwx//px-cluster-foo-fbbf5c0aabb6 for endpoint(s): [http://10.13.1.19:2379]"
time="2023-12-02T08:52:00Z" level=info msg="Delete done."
Portworx cluster wipe succesfully completed.
Cleaning up resources...
job.batch "talisman" deleted
serviceaccount "talisman-account" deleted
clusterrolebinding.rbac.authorization.k8s.io "talisman-role-binding" deleted
Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "volumeplacementstrategies.portworx.io" not found
```