### PR TITLE
Revert PWX-27968: Add NamespaceSelector parameter to VPS spec (#136)

### DIFF
--- a/pkg/apis/portworx/v1beta2/types.go
+++ b/pkg/apis/portworx/v1beta2/types.go
@@ -68,7 +68,4 @@ type CommonPlacementSpec struct {
 	TopologyKey string `json:"topologyKey,omitempty"`
 	// MatchExpressions is a list of label selector requirements. The requirements are ANDed.
 	MatchExpressions []*v1beta1.LabelSelectorRequirement `json:"matchExpressions,omitempty"`
-	// NamespaceSelector is a list of label selector requirements. The requirements are ANDed.
-	// It defines the scope of the VPS volume rule so that it only matches against volumes from the specified namespaces
-	NamespaceSelector []*v1beta1.LabelSelectorRequirement `json:"namespaceSelector,omitempty"`
 }

--- a/pkg/apis/portworx/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/portworx/v1beta2/zz_generated.deepcopy.go
@@ -39,17 +39,6 @@ func (in *CommonPlacementSpec) DeepCopyInto(out *CommonPlacementSpec) {
 			}
 		}
 	}
-	if in.NamespaceSelector != nil {
-		in, out := &in.NamespaceSelector, &out.NamespaceSelector
-		*out = make([]*v1beta1.LabelSelectorRequirement, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(v1beta1.LabelSelectorRequirement)
-				(*in).DeepCopyInto(*out)
-			}
-		}
-	}
 	return
 }
 


### PR DESCRIPTION
NamespaceSelector is no longer needed, thus reverting this change.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

